### PR TITLE
Fix build error

### DIFF
--- a/scripts/dtc/dtc-lexer.l
+++ b/scripts/dtc/dtc-lexer.l
@@ -38,7 +38,7 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
+extern YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
refer to 'https://m.blog.naver.com/PostView.nhn?isHttpsRedirect=true&blogId=ppdha&logNo=222169415924&proxyReferer='

error message:
/usr/bin/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x50): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here

refer to 'https://forum.xda-developers.com/t/multiple-definitions-in-dtc-error-when-trying-to-build-android-kernel.4123549/' diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped -YYLTYPE yylloc;
+extern YYLTYPE yylloc;